### PR TITLE
Issue #12 Improve profile picture layout 

### DIFF
--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -1,7 +1,7 @@
 .profile {
     background-color: #133667 !important;
     text-align: center;
-    height: 320px;
+    min-height: 320px;
     margin-bottom: 50px;
     h1 {
         font-size: 50px;
@@ -13,14 +13,20 @@
         border-radius: 50%;
         max-width: 100%;
         max-height: 100%;
-        margin-left: auto;
-        margin-right: auto;
         display: inline;        
         padding: 20px;
     }
     
     .profile-picture {
         margin-bottom: 30px;
-        height: 200px;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        img {
+            flex: 1 0 50%; // 50% basis: 2 columns small screen
+            min-width: 100px;
+            max-width: 200px;
+        }
     }
 }

--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -1,7 +1,7 @@
 .profile {
     background-color: #133667 !important;
     text-align: center;
-    padding-bottom: 20px;
+    padding-bottom: 10px;
     margin-bottom: 50px;
     h1 {
         font-size: 50px;

--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -1,7 +1,7 @@
 .profile {
     background-color: #133667 !important;
     text-align: center;
-    min-height: 320px;
+    padding-bottom: 20px;
     margin-bottom: 50px;
     h1 {
         font-size: 50px;

--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -8,15 +8,7 @@
         font-weight: 700;
         color: white;
     }
-    
-    img {
-        border-radius: 50%;
-        max-width: 100%;
-        max-height: 100%;
-        display: inline;        
-        padding: 20px;
-    }
-    
+        
     .profile-picture {
         margin-bottom: 30px;
         display: flex;
@@ -27,6 +19,10 @@
             flex: 1 0 50%; // 50% basis: 2 columns small screen
             min-width: 100px;
             max-width: 200px;
+            aspect-ratio: 1/1;
+            border-radius: 50%;
+            display: inline;
+            padding: 20px;   
         }
     }
 }


### PR DESCRIPTION
This pull request addresses [Issue #12](https://github.com/MLH-Fellowship/prep-portfolio-22.JUL.PREP.3/issues/12). 

I added flexbox to the profile-picture div and set the images' flex basis to 50% because on small screens this gives us two columns of images, which I thought looked nice. I added bottom padding to the profile container div to make it look like it did before, but more responsive.

This is important so the images do not overflow the portfolio content on small screens.

Before
![before-pr](https://user-images.githubusercontent.com/71813760/178560267-ff4a3e0e-9f86-46e7-82ae-0b09493e209c.png)

After
![after-pr](https://user-images.githubusercontent.com/71813760/178560280-1429899c-9573-429f-b5f3-12fc34b54bfd.png)



- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.
