### PR TITLE
updated Pod leaderboard stats and styling

### DIFF
--- a/_data/fellows.yml
+++ b/_data/fellows.yml
@@ -62,7 +62,7 @@
   programming_language: JavaScript, Java
   interest: Music, Twitter, Socializing
   github-username: shehabadel
-  
+
 - name: A.S.L.Manasa
   img: aslmanasa.jpeg
   location: India
@@ -128,12 +128,6 @@
   interest: Watching films and design
   github-username: indywip
 
-- name: Julian Willis
-  github-username: gibbonhug
-
-- name: Sadiq Babalola
-  github-username: sadiq-b
-
 - name: Elmar
   img: elmar.png
   location: Azerbaijan
@@ -145,6 +139,7 @@
   resume: https://docs.google.com/document/d/11gH6tybnpcu4dNIOgvlKynqazTGiXMctsk8q0gO5JW0/edit?usp=sharing
   programming_language: JS, Python
   interest: Travel
+  github-username: elmar8287
 
 - name: Vy Nguyen
   img: vy.jpeg
@@ -157,6 +152,7 @@
   resume:
   programming_language: Python, JavaScript
   interest: Camping, Hiking, Photography
+  github-username: thucvy
 
 - name: Di Wu
   img: diwu.png
@@ -169,6 +165,7 @@
   resume: https://drive.google.com/file/d/1s82rODoZMsGOdm2ro1tONndVExn2u_Ds/view
   programming_language: Java
   interest: Anime
+  github-username: dw2761
 
 - name: Sadiq Babalola
   img: sadiq.png
@@ -181,6 +178,7 @@
   resume: https://docs.google.com/document/d/1gz4PvtjLmuTSwk3lFgdgtmpUQlIWuRjq
   programming_language: Python, JavaScript
   interest: Football, Music
+  github-username: sadiq-b
 
 - name: Julian Willis
   img: mlh.jpg
@@ -193,3 +191,4 @@
   resume:
   programming_language:
   interest:
+  github-username: gibbonhug

--- a/_includes/stats.html
+++ b/_includes/stats.html
@@ -80,7 +80,7 @@
 
 <!-- Layout -->
 <div class="leaderboard">
-  <h2 class="pb-md-4 pb-2">Leaderboard</h2>
+  <h2 class="pb-md-4 pb-2 leaderboard-title">Leaderboard</h2>
   <table class="table">
     <thead class="head-blue">
       <tr>

--- a/_includes/stats.html
+++ b/_includes/stats.html
@@ -29,7 +29,7 @@
           for(let i=0; i<data.length; i++){
             
             const item = data[i];
-            const PRsbyFellow = value1.filter((pr) => pr.user.login==item.github_username);
+            const PRsbyFellow = value1.filter((pr) => pr.user.login==item.github_username && pr.merged_at != null);
             const PRsbyFellowOpened = value2.filter((pr) => pr.user.login==item.github_username);
             const commitsbyFellow = value3.filter((commit)=>commit.author.login == item.github_username);
             
@@ -86,7 +86,7 @@
       <tr>
         <th scope="col" class="pl-3">S.No.</th>
         <th scope="col">Fellow</th>
-        <th scope="col"><span class="open">Closed</span> PRs</th>
+        <th scope="col"><span class="open">Merged</span> PRs</th>
         <th scope="col" class="open">Open PRs</th>
         <th scope="col" class="open">Commits</th>
       </tr>

--- a/_includes/stats.html
+++ b/_includes/stats.html
@@ -86,7 +86,7 @@
       <tr>
         <th scope="col" class="pl-3">S.No.</th>
         <th scope="col">Fellow</th>
-        <th scope="col"><span class="open">Merged</span> PRs</th>
+        <th scope="col"><span class="open">Closed</span> PRs</th>
         <th scope="col" class="open">Open PRs</th>
         <th scope="col" class="open">Commits</th>
       </tr>

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -9,6 +9,9 @@
         border-radius: 50%;
         object-fit: cover;
     }
+    .leaderboard-title{
+      font-size: 2.5vh;
+    }
     table {
       padding-left: 40px;
       box-shadow: 0px 2px 6px 0px #aac;


### PR DESCRIPTION
Fixed the bug where for some pod members the merged PR , open PR counts and commit counts were displayed 0 because of wrong or no github username in fellows.yml. Also updated the styling of the Leaderboard header.

Before:

![Screenshot from 2022-07-15 16-58-48](https://user-images.githubusercontent.com/61612477/179214828-41e65a3e-ec6c-4318-8da8-26f608c68ab1.png)

After: 
![Screenshot from 2022-07-15 16-53-03](https://user-images.githubusercontent.com/61612477/179214874-a1f697f0-bec9-42da-94e5-bdfdb3e547af.png)


